### PR TITLE
fix too many arguments for class template in cutlass global_load

### DIFF
--- a/csrc/permute.cu
+++ b/csrc/permute.cu
@@ -51,7 +51,7 @@ __global__ void moe_permute_kernel(const T *original_input,
 
     for (int tid = threadIdx.x * kElementsPerAccess; tid < num_cols; tid += blockDim.x * kElementsPerAccess)
     {
-        cutlass::arch::global_load<float4, sizeof(float4), cutlass::arch::CacheOperation::LastUse>(
+        cutlass::arch::global_load<float4, sizeof(float4)>(
             *(float4 *)(dest_row_ptr + tid), (source_row_ptr + tid), true);
     }
 }
@@ -78,7 +78,7 @@ __global__ void moe_recover_kernel(const T *original_input,
 
     for (int tid = threadIdx.x * kElementsPerAccess; tid < num_cols; tid += blockDim.x * kElementsPerAccess)
     {
-        cutlass::arch::global_load<float4, sizeof(float4), cutlass::arch::CacheOperation::LastUse>(
+        cutlass::arch::global_load<float4, sizeof(float4)>(
             *(float4 *)(dest_row_ptr + tid), (source_row_ptr + tid), true);
     }
 }


### PR DESCRIPTION
Some errors were encountered while installing in `nvcr.io/nvidia/pytorch:24.03-py3`
```
      /grouped_gemm/csrc/permute.cu(54): error: too many arguments for class template "cutlass::arch::global_load"
                cutlass::arch::global_load<float4, sizeof(float4), cutlass::arch::CacheOperation::LastUse>(
                                                                   ^
      
      /grouped_gemm/csrc/permute.cu(54): error: expected a declaration
                cutlass::arch::global_load<float4, sizeof(float4), cutlass::arch::CacheOperation::LastUse>(
                ^
      
      /grouped_gemm/csrc/permute.cu(81): error: too many arguments for class template "cutlass::arch::global_load"
                cutlass::arch::global_load<float4, sizeof(float4), cutlass::arch::CacheOperation::LastUse>(
                                                                   ^
      
      /grouped_gemm/csrc/permute.cu(81): error: expected a declaration
                cutlass::arch::global_load<float4, sizeof(float4), cutlass::arch::CacheOperation::LastUse>(
                ^
      
      4 errors detected in the compilation of "/grouped_gemm/csrc/permute.cu".
```