### PR TITLE
Use `cublasGemmGroupedBatchedEx` in cublas 12.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,9 @@ if device_capability:
         f"-DGROUPED_GEMM_DEVICE_CAPABILITY={device_capability}",
     ])
 
+if "CUBLAS_VERSION" in os.environ:
+    nvcc_flags.append(f"-DCUBLAS_VERSION={os.environ['CUBLAS_VERSION']}")
+
 ext_modules = [
     CUDAExtension(
         "grouped_gemm_backend",


### PR DESCRIPTION
Hi!

This PR is an attempt to use the `cublasGemmGroupedBatchedEx` api [introduced in cublas 12.5](https://developer.nvidia.com/blog/introducing-grouped-gemm-apis-in-cublas-and-more-performance-updates/) to calculate the grouped gemm. And the code has passed `op_test.py`.

There is an potential optimization that is not implemented yet. The origin `grouped_gemm` requires an `batch_sizes` variable on CPU. However, for `cublasGemmGroupedBatchedEx`, the `Aarray`, `Barray` and `Carray` need to be located on device, which will move the CPU array back to GPU. And I think that we could allow the `batch_sizes` on GPU for this branch and calculate the `d_Aarray` on torch with `tensor.data_ptr()` and `batch_sizes`.

Making everything on GPU would reduce the synchronization on all streams during training and potentially make the training faster. But it may require more changes on the current codebase. I wonder if you could share your preference on this? Thank you!

Also, it would be great if you could tell me the benchmark I need to compare this code with the origin branch :)